### PR TITLE
`typing` compatibility

### DIFF
--- a/dirty_equals/_base.py
+++ b/dirty_equals/_base.py
@@ -1,16 +1,8 @@
 from abc import ABCMeta
-from typing import TYPE_CHECKING, Any, Dict, Generic, Iterable, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, Generic, Iterable, Optional, Tuple, TypeVar, Union
 
-try:
-    from typing import Protocol
-except ImportError:
-    # Python 3.7 doesn't have Protocol
-    Protocol = object  # type: ignore[assignment]
-
+from ._compat import Protocol, TypeAlias
 from ._utils import Omit
-
-if TYPE_CHECKING:
-    from typing import TypeAlias
 
 __all__ = 'DirtyEqualsMeta', 'DirtyEquals', 'IsInstance', 'AnyThing', 'IsOneOf'
 
@@ -138,7 +130,7 @@ class DirtyEquals(Generic[T], metaclass=DirtyEqualsMeta):
             return self._repr_ne()
 
 
-InstanceOrType: 'TypeAlias' = 'Union[DirtyEquals[Any], DirtyEqualsMeta]'
+InstanceOrType: TypeAlias = Union[DirtyEquals[Any], DirtyEqualsMeta]
 
 
 class DirtyOr(DirtyEquals[Any]):

--- a/dirty_equals/_compat.py
+++ b/dirty_equals/_compat.py
@@ -1,0 +1,13 @@
+import sys
+
+if sys.version_info[:2] >= (3, 8):
+    from typing import Literal, Protocol
+else:
+    from typing_extensions import Literal, Protocol
+
+if sys.version_info[:2] >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
+__all__ = ['Literal', 'Protocol', 'TypeAlias']

--- a/dirty_equals/_other.py
+++ b/dirty_equals/_other.py
@@ -3,12 +3,8 @@ from typing import Any, Callable, TypeVar, overload
 from uuid import UUID
 
 from ._base import DirtyEquals
+from ._compat import Literal
 from ._utils import plain_repr
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore[misc]
 
 
 class IsUUID(DirtyEquals[UUID]):

--- a/dirty_equals/_sequence.py
+++ b/dirty_equals/_sequence.py
@@ -1,14 +1,12 @@
-from typing import TYPE_CHECKING, Any, Container, Dict, List, Optional, Sized, Tuple, Type, TypeVar, Union, overload
+from typing import Any, Container, Dict, List, Optional, Sized, Tuple, Type, TypeVar, Union, overload
 
 from ._base import DirtyEquals
+from ._compat import TypeAlias
 from ._utils import Omit, plain_repr
-
-if TYPE_CHECKING:
-    from typing import TypeAlias
 
 __all__ = 'HasLen', 'Contains', 'IsListOrTuple', 'IsList', 'IsTuple'
 T = TypeVar('T', List[Any], Tuple[Any, ...])
-LengthType: 'TypeAlias' = 'Union[None, int, Tuple[int, Union[int, Any]]]'
+LengthType: TypeAlias = Union[None, int, Tuple[int, Union[int, Any]]]
 
 
 class HasLen(DirtyEquals[Sized]):

--- a/dirty_equals/_strings.py
+++ b/dirty_equals/_strings.py
@@ -2,12 +2,8 @@ import re
 from typing import Any, Optional, Pattern, Tuple, Type, TypeVar, Union
 
 from ._base import DirtyEquals
+from ._compat import Literal
 from ._utils import Omit, plain_repr
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore[misc]
 
 T = TypeVar('T', str, bytes)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7.0"
-typing-extensions = {version = "^4.0.1", python = "<3.8"}
+typing-extensions = "^4.0.1"
 pytz = "^2021.3"
 
 [build-system]


### PR DESCRIPTION
I was trying out this cool new library and noticed some mypy errors on python 3.9.9 after cloning:

```bash
$ make mypy
mypy --show-error-codes dirty_equals
dirty_equals/_base.py:13: error: Module "typing" has no attribute "TypeAlias"  [attr-defined]
dirty_equals/_base.py:32: error: Unused "type: ignore" comment
dirty_equals/_sequence.py:7: error: Module "typing" has no attribute "TypeAlias"  [attr-defined]
```

this pr is a suggestion to add a `_compat.typing` module for handling the use of backports when the python version requires them
https://mypy.readthedocs.io/en/stable/common_issues.html#python-version-and-system-platform-checks