### PR TITLE
Make IsNow relative to current moment of time

### DIFF
--- a/dirty_equals/_datetime.py
+++ b/dirty_equals/_datetime.py
@@ -163,13 +163,12 @@ class IsNow(IsDatetime):
 
             tz = pytz.timezone(tz)
 
-        if tz is not None:
-            now = datetime.utcnow().replace(tzinfo=timezone.utc).astimezone(tz)
-        else:
-            now = datetime.now()
+        self.tz = tz
+
+        approx = self._get_now()
 
         super().__init__(
-            approx=now,
+            approx=approx,
             delta=delta,
             unix_number=unix_number,
             iso_string=iso_string,
@@ -178,6 +177,20 @@ class IsNow(IsDatetime):
         )
         if tz is not None:
             self._repr_kwargs['tz'] = tz
+
+    def _get_now(self) -> datetime:
+        if self.tz is None:
+            return datetime.now()
+        else:
+            return datetime.utcnow().replace(tzinfo=timezone.utc).astimezone(self.tz)
+
+    def prepare(self, other: Any) -> datetime:
+
+        # update approx for every comparing, to check if other value is dirty equal
+        # to current moment of time
+        self.approx = self._get_now()
+
+        return super().prepare(other)
 
 
 class IsDate(IsNumeric[date]):

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, timedelta, timezone
+from unittest.mock import Mock
 
 import pytest
 import pytz
@@ -25,7 +26,6 @@ from dirty_equals import IsDate, IsDatetime, IsNow, IsToday
         ),
         pytest.param('28/01/87', IsDatetime(approx=datetime(2000, 1, 1)), False, id='string-format-different'),
         pytest.param('foobar', IsDatetime(approx=datetime(2000, 1, 1)), False, id='string-format-wrong'),
-        pytest.param(datetime.now().isoformat(), IsNow(iso_string=True), True, id='isnow-str-true'),
         pytest.param(datetime(2000, 1, 1).isoformat(), IsNow(iso_string=True), False, id='isnow-str-different'),
         pytest.param([1, 2, 3], IsDatetime(approx=datetime(2000, 1, 1)), False, id='wrong-type'),
         pytest.param(
@@ -119,6 +119,12 @@ def test_delta():
     assert IsNow(delta=timedelta(hours=2)).delta == timedelta(seconds=7200)
     assert IsNow(delta=3600).delta == timedelta(seconds=3600)
     assert IsNow(delta=3600.1).delta == timedelta(seconds=3600, microseconds=100000)
+
+
+def test_is_now_relative(monkeypatch):
+    mock = Mock(return_value=datetime(2020, 1, 1, 12, 13, 14))
+    monkeypatch.setattr(IsNow, '_get_now', mock)
+    assert IsNow() == datetime(2020, 1, 1, 12, 13, 14)
 
 
 def test_tz():


### PR DESCRIPTION
Issue: https://github.com/samuelcolvin/dirty-equals/issues/39

Implemented logic that updates the` approx` value of IsNow for every comparison. Other ideas, that I've considered:

- set the `approx` value to None and generate now on every comparison. Downside -- hard to make repr
- set the `approx` value to the current time on `__ini__` and do not use it for comparison. Downside -- repr will be lying.
- Remove internal state from `IsNow` and on every compassion create an instance of class DateTime and use it for comparing with `other` value.  More work, so I started from the easiest one.

The downside of my implementation is that the internal state is changing for every comparison, instead of not having a state at all.