### PR TITLE
Depend on typing-extensions only for Python < 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 requires-python = '>=3.7'
 dependencies = [
-    'typing-extensions>=4.0.1',
+    'typing-extensions>=4.0.1;python_version<"3.8"',
     'pytz>=2021.3',
 ]
 dynamic = ['version']


### PR DESCRIPTION
typing.Literal is part of stdlib since Python 3.8, and since this is
the only type where fallback to typing-extensions is used, this package
is never used in Python 3.8 and newer.  Update the dependency
accordingly.