### PR TITLE
Add assert_equal(..., reple={"selector": value"})

### DIFF
--- a/dirty_equals/_other.py
+++ b/dirty_equals/_other.py
@@ -35,7 +35,7 @@ class IsUUID(DirtyEquals[UUID]):
         ```
         """
         self.version = version
-        super().__init__(version or plain_repr('*'))
+        super().__init__(version or plain_repr(''))
 
     def equals(self, other: Any) -> bool:
         if isinstance(other, UUID):


### PR DESCRIPTION
I took a stab at implementing this. Here are some of the blockers I've found:
1. The dirty equals types don't respect the property of `eval(repr(item)) == item`.
2. Imports and reprs: if users do `from datetime import datetime` the repr will still be `datetime.datetime(...)`. And obviously we can't support `repl={'["id"]': uuid4()}` because the repr is going to be `UUID(...)` but that's expected.
3. Unused imports: if the user does `from dirty_equals import IsNow` then when we comment out the `insert_assert(...)` line  linters will complain about `IsNow` being unused. Do we comment out imports as well? I'm somewhat at a loss on this one. 

Maybe the answer is to not comment out the `insert_assert` line but instead just make it a no-op as long as the generated `expected_value` matches the current one. This would fix all of the above issues but it also means that if you uninstall `dirty-equals` all of your tests will now be broken and you'd have to go and delete all of the `insert_assert` statements. I thought commenting that line out was nice because the end result can run without even having `dirty-equals` installed or knowing how `insert_assert` works...