### PR TITLE
IsDataclass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ yarn-debug.log*
 yarn-error.log*
 /TODO.md
 /.mypy_cache/
+/.ruff_cache/
 /scratch/
 /site/

--- a/dirty_equals/__init__.py
+++ b/dirty_equals/__init__.py
@@ -22,7 +22,18 @@ from ._numeric import (
     IsPositiveFloat,
     IsPositiveInt,
 )
-from ._other import FunctionCheck, IsDataclass, IsDataclassType, IsHash, IsIP, IsJson, IsPartialDataclass, IsUrl, IsUUID
+from ._other import (
+    FunctionCheck,
+    IsDataclass,
+    IsDataclassType,
+    IsHash,
+    IsIP,
+    IsJson,
+    IsPartialDataclass,
+    IsStrictDataclass,
+    IsUrl,
+    IsUUID,
+)
 from ._sequence import Contains, HasLen, IsList, IsListOrTuple, IsTuple
 from ._strings import IsAnyStr, IsBytes, IsStr
 from .version import VERSION
@@ -39,6 +50,7 @@ __all__ = (
     'IsDataclass',
     'IsDataclassType',
     'IsPartialDataclass',
+    'IsStrictDataclass',
     # datetime
     'IsDatetime',
     'IsNow',

--- a/dirty_equals/__init__.py
+++ b/dirty_equals/__init__.py
@@ -22,7 +22,7 @@ from ._numeric import (
     IsPositiveFloat,
     IsPositiveInt,
 )
-from ._other import FunctionCheck, IsHash, IsIP, IsJson, IsUrl, IsUUID
+from ._other import FunctionCheck, IsDataclass, IsDataclassType, IsHash, IsIP, IsJson, IsPartialDataclass, IsUrl, IsUUID
 from ._sequence import Contains, HasLen, IsList, IsListOrTuple, IsTuple
 from ._strings import IsAnyStr, IsBytes, IsStr
 from .version import VERSION
@@ -35,6 +35,10 @@ __all__ = (
     # boolean
     'IsTrueLike',
     'IsFalseLike',
+    # dataclass
+    'IsDataclass',
+    'IsDataclassType',
+    'IsPartialDataclass',
     # datetime
     'IsDatetime',
     'IsNow',

--- a/dirty_equals/_other.py
+++ b/dirty_equals/_other.py
@@ -528,8 +528,14 @@ class IsStrictDataclass(IsDataclass):
     foo = Foo(1, 2, 'c')
 
     assert foo == IsStrictDataclass
-    assert foo == IsStrictDataclass(a=IsInt, b=2,).settings(partial=True)
-    assert foo != IsStrictDataclass(a=IsInt, b=2,).settings(partial=False)
+    assert foo == IsStrictDataclass(
+        a=IsInt,
+        b=2,
+    ).settings(partial=True)
+    assert foo != IsStrictDataclass(
+        a=IsInt,
+        b=2,
+    ).settings(partial=False)
     assert foo != IsStrictDataclass(b=2, a=IsInt, c='c')
     ```
     """

--- a/dirty_equals/_other.py
+++ b/dirty_equals/_other.py
@@ -391,9 +391,7 @@ class IsDataclassType(DirtyEquals[Any]):
     foo = Foo(1, 2)
 
     assert Foo == IsDataclassType
-    assert Foo == IsDataclassType()
     assert foo != IsDataclassType
-    assert foo != IsDataclassType()
     ```
     """
 
@@ -420,7 +418,6 @@ class IsDataclass(DirtyEquals[Any]):
     foo = Foo(1, 2)
 
     assert foo == IsDataclass
-    assert foo == IsDataclass()
     assert foo == IsDataclass(a=1, b=2)
     assert foo == IsDataclass(a=IsInt, b=2)
     assert foo != IsDataclass(a=1)
@@ -462,10 +459,9 @@ class IsPartialDataclass(DirtyEquals[Any]):
     foo = Foo(1, 2)
 
     assert foo == IsPartialDataclass
-    assert foo == IsPartialDataclass()
     assert foo == IsPartialDataclass(a=1)
     assert foo == IsPartialDataclass(a=IsInt)
-    assert not (Foo == IsPartialDataclass)
+    assert Foo != IsPartialDataclass
     """
 
     def __init__(self, **repr_kwargs: Any):

--- a/dirty_equals/_other.py
+++ b/dirty_equals/_other.py
@@ -415,7 +415,7 @@ class IsDataclass(DirtyEquals[Any]):
 
     ```py title="IsDataclass"
     from dataclasses import dataclass
-    from dirty_equals import IsDataclass, IsInt
+    from dirty_equals import IsInt, IsDataclass
 
     @dataclass
     class Foo:
@@ -489,7 +489,7 @@ class IsPartialDataclass(IsDataclass):
 
     ```py title="IsPartialDataclass"
     from dataclasses import dataclass
-    from dirty_equals import IsPartialDataclass, IsInt
+    from dirty_equals import IsInt, IsPartialDataclass
 
     @dataclass
     class Foo:
@@ -502,7 +502,7 @@ class IsPartialDataclass(IsDataclass):
     assert foo == IsPartialDataclass
     assert foo == IsPartialDataclass(a=1)
     assert foo == IsPartialDataclass(b=2, a=IsInt)
-    assert foo == IsPartialDataclass(b=2, a=IsInt).settings(strict=True)
+    assert foo != IsPartialDataclass(b=2, a=IsInt).settings(strict=True)
     assert Foo != IsPartialDataclass
     ```
     """
@@ -517,7 +517,7 @@ class IsStrictDataclass(IsDataclass):
 
     ```py title="IsStrictDataclass"
     from dataclasses import dataclass
-    from dirty_equals import IsStrictDataclass, IsInt
+    from dirty_equals import IsInt, IsStrictDataclass
 
     @dataclass
     class Foo:
@@ -525,7 +525,7 @@ class IsStrictDataclass(IsDataclass):
         b: int
         c: str = 'c'
 
-    foo = Foo(a=1, b=2)
+    foo = Foo(1, 2, 'c')
 
     assert foo == IsStrictDataclass
     assert foo == IsStrictDataclass(a=IsInt, b=2,).settings(partial=True)

--- a/dirty_equals/_other.py
+++ b/dirty_equals/_other.py
@@ -428,10 +428,12 @@ class IsDataclass(DirtyEquals[Any]):
     ```
     """
 
-    def __init__(self, **kwargs: Any):
-        super().__init__(**kwargs)
+    def __init__(self, **repr_kwargs: Any):
+        """key-value pairs are used to check exactness of instance attributes."""
+        super().__init__(**repr_kwargs)
 
     def equals(self, other: Any) -> bool:
+        """Checks attributes only if any keyword argument is passed during initialization."""
         valid_attrs = self.attrs_checks(other) if self._repr_kwargs else True
         return is_dataclass(other) and not isinstance(other, type) and valid_attrs
 
@@ -466,10 +468,12 @@ class IsPartialDataclass(DirtyEquals[Any]):
     assert not (Foo == IsPartialDataclass)
     """
 
-    def __init__(self, **kwargs: Any):
-        super().__init__(**kwargs)
+    def __init__(self, **repr_kwargs: Any):
+        """key-value pairs are used to check partial exactness of instance attributes."""
+        super().__init__(**repr_kwargs)
 
     def equals(self, other: Any) -> bool:
+        """Checks attributes only if any keyword argument is passed during initialization."""
         valid_attrs = self.attrs_checks(other) if self._repr_kwargs else True
         return is_dataclass(other) and not isinstance(other, type) and valid_attrs
 

--- a/dirty_equals/_other.py
+++ b/dirty_equals/_other.py
@@ -1,10 +1,12 @@
 import json
 import re
+from dataclasses import is_dataclass
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network, ip_network
 from typing import Any, Callable, Optional, Set, TypeVar, Union, overload
 from uuid import UUID
 
 from ._base import DirtyEquals
+from ._dict import IsDict, IsPartialDict
 from ._utils import Omit, plain_repr
 
 try:
@@ -369,3 +371,48 @@ class IsIP(DirtyEquals[IP]):
                 return False
 
         return True
+
+
+class IsDataclassType(DirtyEquals[Any]):
+    """
+    A class that checks if an object is a dataclass type.
+    """
+
+    def equals(self, other: Any) -> bool:
+        return is_dataclass(other) and isinstance(other, type)
+
+
+class IsDataclass(DirtyEquals[Any]):
+    """
+    A class that checks if an object is an instance of a dataclass.
+    """
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+
+    def equals(self, other: Any) -> bool:
+        if self._repr_kwargs:
+            return is_dataclass(other) and not isinstance(other, type) and self.attrs_checks(other)
+        else:
+            return is_dataclass(other) and not isinstance(other, type)
+
+    def attrs_checks(self, other: Any) -> bool:
+        return other.__dict__ == IsDict(self._repr_kwargs)
+
+
+class IsPartialDataclass(DirtyEquals[Any]):
+    """
+    A class that checks if an object is an instance of a dataclass.
+    """
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+
+    def equals(self, other: Any) -> bool:
+        if self._repr_kwargs:
+            return is_dataclass(other) and not isinstance(other, type) and self.attrs_checks(other)
+        else:
+            return is_dataclass(other) and not isinstance(other, type)
+
+    def attrs_checks(self, other: Any) -> bool:
+        return other.__dict__ == IsPartialDict(self._repr_kwargs)

--- a/dirty_equals/_other.py
+++ b/dirty_equals/_other.py
@@ -375,7 +375,26 @@ class IsIP(DirtyEquals[IP]):
 
 class IsDataclassType(DirtyEquals[Any]):
     """
-    A class that checks if an object is a dataclass type.
+    Checks that an object is a dataclass type.
+
+    Inherits from [`DirtyEquals`][dirty_equals.DirtyEquals].
+
+    ```py title="IsDataclassType"
+    from dataclasses import dataclass
+    from dirty_equals import IsDataclassType
+
+    @dataclass
+    class Foo:
+        a: int
+        b: int
+
+    foo = Foo(1, 2)
+
+    assert Foo == IsDataclassType
+    assert Foo == IsDataclassType()
+    assert foo != IsDataclassType
+    assert foo != IsDataclassType()
+    ```
     """
 
     def equals(self, other: Any) -> bool:
@@ -384,35 +403,76 @@ class IsDataclassType(DirtyEquals[Any]):
 
 class IsDataclass(DirtyEquals[Any]):
     """
-    A class that checks if an object is an instance of a dataclass.
+    Checks that an object is an instance of a dataclass.
+
+    Inherits from [`DirtyEquals`][dirty_equals.DirtyEquals] and it can be initialised with specific keyword arguments to
+    check exactness of instance attributes by comparing the instance `__dict__`  with [`IsDict`][dirty_equals.IsDict].
+
+    ```py title="IsDataclass"
+    from dataclasses import dataclass
+    from dirty_equals import IsDataclass, IsInt
+
+    @dataclass
+    class Foo:
+        a: int
+        b: int
+
+    foo = Foo(1, 2)
+
+    assert foo == IsDataclass
+    assert foo == IsDataclass()
+    assert foo == IsDataclass(a=1, b=2)
+    assert foo == IsDataclass(a=IsInt, b=2)
+    assert foo != IsDataclass(a=1)
+    assert Foo != IsDataclass
+    ```
     """
 
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
 
     def equals(self, other: Any) -> bool:
-        if self._repr_kwargs:
-            return is_dataclass(other) and not isinstance(other, type) and self.attrs_checks(other)
-        else:
-            return is_dataclass(other) and not isinstance(other, type)
+        valid_attrs = self.attrs_checks(other) if self._repr_kwargs else True
+        return is_dataclass(other) and not isinstance(other, type) and valid_attrs
 
     def attrs_checks(self, other: Any) -> bool:
+        """Checks exactness of attributes using [`IsDict`][dirty_equals.IsDict]."""
         return other.__dict__ == IsDict(self._repr_kwargs)
 
 
 class IsPartialDataclass(DirtyEquals[Any]):
     """
-    A class that checks if an object is an instance of a dataclass.
+    Checks that an object is an instance of a dataclass.
+
+    Inherits from [`DirtyEquals`][dirty_equals.DirtyEquals] and it can be initialised with specific keyword arguments to
+    check partial exactness of instance attributes by comparing the instance `__dict__`  with
+    [`IsPartialDict`][dirty_equals.IsPartialDict].
+
+    ```py title="IsPartialDataclass"
+    from dataclasses import dataclass
+    from dirty_equals import IsPartialDataclass, IsInt
+
+    @dataclass
+    class Foo:
+        a: int
+        b: int
+
+    foo = Foo(1, 2)
+
+    assert foo == IsPartialDataclass
+    assert foo == IsPartialDataclass()
+    assert foo == IsPartialDataclass(a=1)
+    assert foo == IsPartialDataclass(a=IsInt)
+    assert not (Foo == IsPartialDataclass)
     """
 
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
 
     def equals(self, other: Any) -> bool:
-        if self._repr_kwargs:
-            return is_dataclass(other) and not isinstance(other, type) and self.attrs_checks(other)
-        else:
-            return is_dataclass(other) and not isinstance(other, type)
+        valid_attrs = self.attrs_checks(other) if self._repr_kwargs else True
+        return is_dataclass(other) and not isinstance(other, type) and valid_attrs
 
     def attrs_checks(self, other: Any) -> bool:
+        """Checks partial exactness of attributes using [`IsPartialDict`][dirty_equals.IsPartialDict]."""
         return other.__dict__ == IsPartialDict(self._repr_kwargs)

--- a/dirty_equals/_other.py
+++ b/dirty_equals/_other.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Optional, Set, TypeVar, Union, overload
 from uuid import UUID
 
 from ._base import DirtyEquals
-from ._dict import IsDict, IsPartialDict
+from ._dict import IsPartialDict, IsStrictDict
 from ._utils import Omit, plain_repr
 
 try:
@@ -404,7 +404,8 @@ class IsDataclass(DirtyEquals[Any]):
     Checks that an object is an instance of a dataclass.
 
     Inherits from [`DirtyEquals`][dirty_equals.DirtyEquals] and it can be initialised with specific keyword arguments to
-    check exactness of instance attributes by comparing the instance `__dict__`  with [`IsDict`][dirty_equals.IsDict].
+    check exactness of instance attributes by comparing the instance `__dict__`  with
+    [`IsStrictDict`][dirty_equals.IsStrictDict].
 
     ```py title="IsDataclass"
     from dataclasses import dataclass
@@ -436,7 +437,7 @@ class IsDataclass(DirtyEquals[Any]):
 
     def attrs_checks(self, other: Any) -> bool:
         """Checks exactness of attributes using [`IsDict`][dirty_equals.IsDict]."""
-        return other.__dict__ == IsDict(self._repr_kwargs)
+        return other.__dict__ == IsStrictDict(self._repr_kwargs)
 
 
 class IsPartialDataclass(DirtyEquals[Any]):

--- a/docs/plugins.py
+++ b/docs/plugins.py
@@ -17,6 +17,7 @@ logger = logging.getLogger('mkdocs.test_examples')
 def on_pre_build(config: Config):
     pass
 
+
 def on_files(files: Files, config: Config) -> Files:
     return remove_files(files)
 

--- a/docs/types/other.md
+++ b/docs/types/other.md
@@ -17,3 +17,9 @@
 ::: dirty_equals.IsHash
 
 ::: dirty_equals.IsIP
+
+::: dirty_equals.IsDataclass
+
+::: dirty_equals.IsPartialDataclass
+
+::: dirty_equals.IsDataclassType

--- a/docs/types/other.md
+++ b/docs/types/other.md
@@ -18,8 +18,10 @@
 
 ::: dirty_equals.IsIP
 
+::: dirty_equals.IsDataclassType
+
 ::: dirty_equals.IsDataclass
 
 ::: dirty_equals.IsPartialDataclass
 
-::: dirty_equals.IsDataclassType
+::: dirty_equals.IsStrictDataclass

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -15,6 +15,7 @@ from dirty_equals import (
     IsJson,
     IsPartialDataclass,
     IsStr,
+    IsStrictDataclass,
     IsUrl,
     IsUUID,
 )
@@ -333,9 +334,15 @@ def test_is_dataclass_type_false(other, dirty):
     [
         (foo, IsDataclass),
         (foo, IsDataclass()),
-        (foo, IsDataclass(a=1, b=2, c='c')),
-        (foo, IsDataclass(b=2, c='c', a=1, strict=False)),
         (foo, IsDataclass(a=IsInt, b=2, c=IsStr)),
+        (foo, IsDataclass(a=1, c='c', b=2).settings(strict=False, partial=False)),
+        (foo, IsDataclass(a=1, b=2, c='c').settings(strict=True, partial=False)),
+        (foo, IsStrictDataclass(a=1, b=2, c='c')),
+        (foo, IsDataclass(c='c', a=1).settings(strict=False, partial=True)),
+        (foo, IsPartialDataclass(c='c', a=1)),
+        (foo, IsDataclass(b=2, c='c').settings(strict=True, partial=True)),
+        (foo, IsStrictDataclass(b=2, c='c').settings(partial=True)),
+        (foo, IsPartialDataclass(b=2, c='c').settings(strict=True)),
     ],
 )
 def test_is_dataclass_true(other, dirty):
@@ -346,34 +353,13 @@ def test_is_dataclass_true(other, dirty):
     'other,dirty',
     [
         (foo, IsDataclassType),
+        (Foo, IsDataclass),
         (foo, IsDataclass(a=1)),
         (foo, IsDataclass(a=IsStr, b=IsInt, c=IsStr)),
-        (foo, IsDataclass(b=2, a=1, c='c', strict=True)),
+        (foo, IsDataclass(b=2, a=1, c='c').settings(strict=True)),
+        (foo, IsStrictDataclass(b=2, a=1, c='c')),
+        (foo, IsDataclass(b=2, a=1).settings(partial=False)),
     ],
 )
 def test_is_dataclass_false(other, dirty):
-    assert other != dirty
-
-
-@pytest.mark.parametrize(
-    'other,dirty',
-    [
-        (foo, IsPartialDataclass),
-        (foo, IsPartialDataclass()),
-        (foo, IsPartialDataclass(a=1, b=2)),
-        (foo, IsPartialDataclass(c=IsStr, a=IsInt, strict=False)),
-    ],
-)
-def test_is_partial_dataclass_true(other, dirty):
-    assert other == dirty
-
-
-@pytest.mark.parametrize(
-    'other,dirty',
-    [
-        (foo, IsPartialDataclass(a=IsStr)),
-        (foo, IsPartialDataclass(c='c', a=1, b=2, strict=True)),
-    ],
-)
-def test_is_partial_dataclass_false(other, dirty):
     assert other != dirty

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -24,9 +24,10 @@ from dirty_equals import (
 class Foo:
     a: int
     b: int
+    c: str
 
 
-foo = Foo(1, 2)
+foo = Foo(1, 2, 'c')
 
 
 @pytest.mark.parametrize(
@@ -329,7 +330,13 @@ def test_is_dataclass_type_false(other, dirty):
 
 @pytest.mark.parametrize(
     'other,dirty',
-    [(foo, IsDataclass), (foo, IsDataclass()), (foo, IsDataclass(a=1, b=2)), (foo, IsDataclass(a=IsInt, b=2))],
+    [
+        (foo, IsDataclass),
+        (foo, IsDataclass()),
+        (foo, IsDataclass(a=1, b=2, c='c')),
+        (foo, IsDataclass(b=2, c='c', a=1, strict=False)),
+        (foo, IsDataclass(a=IsInt, b=2, c=IsStr)),
+    ],
 )
 def test_is_dataclass_true(other, dirty):
     assert other == dirty
@@ -340,6 +347,8 @@ def test_is_dataclass_true(other, dirty):
     [
         (foo, IsDataclassType),
         (foo, IsDataclass(a=1)),
+        (foo, IsDataclass(a=IsStr, b=IsInt, c=IsStr)),
+        (foo, IsDataclass(b=2, a=1, c='c', strict=True)),
     ],
 )
 def test_is_dataclass_false(other, dirty):
@@ -351,8 +360,8 @@ def test_is_dataclass_false(other, dirty):
     [
         (foo, IsPartialDataclass),
         (foo, IsPartialDataclass()),
-        (foo, IsPartialDataclass(a=1)),
-        (foo, IsPartialDataclass(a=IsInt)),
+        (foo, IsPartialDataclass(a=1, b=2)),
+        (foo, IsPartialDataclass(c=IsStr, a=IsInt, strict=False)),
     ],
 )
 def test_is_partial_dataclass_true(other, dirty):
@@ -363,7 +372,7 @@ def test_is_partial_dataclass_true(other, dirty):
     'other,dirty',
     [
         (foo, IsPartialDataclass(a=IsStr)),
-        (foo, IsPartialDataclass(a=2)),
+        (foo, IsPartialDataclass(c='c', a=1, b=2, strict=True)),
     ],
 )
 def test_is_partial_dataclass_false(other, dirty):


### PR DESCRIPTION
Addresses #67 by introducing the following types:

- `IsDataclassType`: checks if type is dataclass.
- `IsDataclass`: checks if instance is dataclass, and possibly checks exact matching of attribute values using `IsDict`.
- `IsPartialDataclass`: checks if instance is dataclass, and possibly checks partial matching of attribute values using `IsPartialDict`.