### PR TITLE
IsEnum

### DIFF
--- a/dirty_equals/__init__.py
+++ b/dirty_equals/__init__.py
@@ -22,7 +22,7 @@ from ._numeric import (
     IsPositiveFloat,
     IsPositiveInt,
 )
-from ._other import FunctionCheck, IsHash, IsIP, IsJson, IsUrl, IsUUID
+from ._other import FunctionCheck, IsEnum, IsEnumType, IsHash, IsIP, IsJson, IsPartialEnumType, IsUrl, IsUUID
 from ._sequence import Contains, HasLen, IsList, IsListOrTuple, IsTuple
 from ._strings import IsAnyStr, IsBytes, IsStr
 from .version import VERSION
@@ -45,6 +45,10 @@ __all__ = (
     'IsPartialDict',
     'IsIgnoreDict',
     'IsStrictDict',
+    # enum
+    'IsEnum',
+    'IsEnumType',
+    'IsPartialEnumType',
     # sequence
     'Contains',
     'HasLen',

--- a/dirty_equals/__init__.py
+++ b/dirty_equals/__init__.py
@@ -22,7 +22,18 @@ from ._numeric import (
     IsPositiveFloat,
     IsPositiveInt,
 )
-from ._other import FunctionCheck, IsEnum, IsEnumType, IsHash, IsIP, IsJson, IsPartialEnumType, IsUrl, IsUUID
+from ._other import (
+    FunctionCheck,
+    IsEnum,
+    IsEnumType,
+    IsHash,
+    IsIP,
+    IsJson,
+    IsPartialEnumType,
+    IsStrictEnumType,
+    IsUrl,
+    IsUUID,
+)
 from ._sequence import Contains, HasLen, IsList, IsListOrTuple, IsTuple
 from ._strings import IsAnyStr, IsBytes, IsStr
 from .version import VERSION
@@ -49,6 +60,7 @@ __all__ = (
     'IsEnum',
     'IsEnumType',
     'IsPartialEnumType',
+    'IsStrictEnumType',
     # sequence
     'Contains',
     'HasLen',

--- a/docs/plugins.py
+++ b/docs/plugins.py
@@ -17,6 +17,7 @@ logger = logging.getLogger('mkdocs.test_examples')
 def on_pre_build(config: Config):
     pass
 
+
 def on_files(files: Files, config: Config) -> Files:
     return remove_files(files)
 

--- a/docs/types/other.md
+++ b/docs/types/other.md
@@ -23,3 +23,5 @@
 ::: dirty_equals.IsEnumType
 
 ::: dirty_equals.IsPartialEnumType
+
+::: dirty_equals.IsStrictEnumType

--- a/docs/types/other.md
+++ b/docs/types/other.md
@@ -17,3 +17,9 @@
 ::: dirty_equals.IsHash
 
 ::: dirty_equals.IsIP
+
+::: dirty_equals.IsEnum
+
+::: dirty_equals.IsEnumType
+
+::: dirty_equals.IsPartialEnumType

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -15,12 +15,13 @@ from dirty_equals import (
     IsJson,
     IsPartialEnumType,
     IsStr,
+    IsStrictEnumType,
     IsUrl,
     IsUUID,
 )
 
 
-class ExampleEnum(Enum):
+class FooEnum(Enum):
     a = auto()
     b = auto()
     c = 'c'
@@ -304,10 +305,10 @@ def test_is_url_too_many_url_types():
 @pytest.mark.parametrize(
     'other,dirty',
     [
-        (ExampleEnum.a, IsEnum),
-        (ExampleEnum.a, IsEnum(ExampleEnum)),
-        (ExampleEnum.c, IsEnum),
-        (ExampleEnum.c, IsEnum(ExampleEnum)),
+        (FooEnum.a, IsEnum),
+        (FooEnum.a, IsEnum(FooEnum)),
+        (FooEnum.c, IsEnum),
+        (FooEnum.c, IsEnum(FooEnum)),
     ],
 )
 def test_is_enum_true(other, dirty):
@@ -317,22 +318,29 @@ def test_is_enum_true(other, dirty):
 @pytest.mark.parametrize(
     'other,dirty',
     [
-        (ExampleEnum, IsEnum),
-        (ExampleEnum, IsEnum(ExampleEnum)),
-        (ExampleEnum.a, IsEnumType),
-        (ExampleEnum.c, IsEnumType),
+        (FooEnum, IsEnum),
+        (FooEnum, IsEnum(FooEnum)),
+        (FooEnum.a, IsEnumType),
+        (FooEnum.c, IsEnumType),
     ],
 )
 def test_is_enum_false(other, dirty):
     assert other != dirty
-
-
+   
+    
 @pytest.mark.parametrize(
     'other,dirty',
     [
-        (ExampleEnum, IsEnumType),
-        (ExampleEnum, IsEnumType(a=1, b=2, c='c')),
-        (ExampleEnum, IsEnumType(a=IsInt, b=IsInt, c=IsStr)),
+        (FooEnum, IsEnumType),
+        (FooEnum, IsEnumType(a=1, b=IsInt, c='c')),
+        (FooEnum, IsEnumType(a=1).settings(partial=True)),
+        (FooEnum, IsEnumType(c=IsStr, b=2).settings(partial=True, strict=False)),
+        (FooEnum, IsPartialEnumType),
+        (FooEnum, IsPartialEnumType(a=1, b=2)),
+        (FooEnum, IsPartialEnumType(c='c', b=2).settings(strict=False)),
+        (FooEnum, IsStrictEnumType),
+        (FooEnum, IsStrictEnumType(a=1, b=2, c=IsStr)),
+        (FooEnum, IsStrictEnumType(b=IsInt, c='c').settings(partial=True)),
     ],
 )
 def test_is_enum_type_true(other, dirty):
@@ -342,36 +350,14 @@ def test_is_enum_type_true(other, dirty):
 @pytest.mark.parametrize(
     'other,dirty',
     [
-        (ExampleEnum, IsEnum),
-        (ExampleEnum, IsEnumType(a=1, b=2)),
-        (ExampleEnum.a, IsEnumType),
+        (FooEnum.a, IsEnumType),
+        (FooEnum, IsEnumType(b=2, a=1, c='c').settings(strict=True)),
+        (FooEnum, IsEnumType(a=1)),
+        (FooEnum, IsPartialEnumType(c='c', b=2).settings(strict=True)),
+        (FooEnum.a, IsPartialEnumType),
+        (FooEnum, IsStrictEnumType(b=2, c='c', a=1)),
+        (FooEnum.a, IsStrictEnumType),
     ],
 )
 def test_is_enum_type_false(other, dirty):
-    assert other != dirty
-
-
-@pytest.mark.parametrize(
-    'other,dirty',
-    [
-        (ExampleEnum, IsPartialEnumType),
-        (ExampleEnum, IsPartialEnumType(a=1, b=2, c='c')),
-        (ExampleEnum, IsPartialEnumType(a=1, b=2)),
-        (ExampleEnum, IsPartialEnumType(a=IsInt, c=IsStr)),
-    ],
-)
-def test_is_partial_enum_type_true(other, dirty):
-    assert other == dirty
-
-
-@pytest.mark.parametrize(
-    'other,dirty',
-    [
-        (ExampleEnum.a, IsPartialEnumType),
-        (ExampleEnum, IsPartialEnumType(a=IsStr)),
-        (ExampleEnum, IsPartialEnumType(c=IsInt)),
-        (ExampleEnum, IsPartialEnumType(d=3)),
-    ],
-)
-def test_is_partial_enum_type_false(other, dirty):
     assert other != dirty

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -368,6 +368,9 @@ def test_is_partial_enum_type_true(other, dirty):
     'other,dirty',
     [
         (ExampleEnum.a, IsPartialEnumType),
+        (ExampleEnum, IsPartialEnumType(a=IsStr)),
+        (ExampleEnum, IsPartialEnumType(c=IsInt)),
+        (ExampleEnum, IsPartialEnumType(d=3)),
     ],
 )
 def test_is_partial_enum_type_false(other, dirty):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -326,8 +326,8 @@ def test_is_enum_true(other, dirty):
 )
 def test_is_enum_false(other, dirty):
     assert other != dirty
-   
-    
+
+
 @pytest.mark.parametrize(
     'other,dirty',
     [

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5,7 +5,19 @@ from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
 
 import pytest
 
-from dirty_equals import FunctionCheck, IsEnum, IsEnumType, IsHash, IsIP, IsJson, IsPartialEnumType, IsUrl, IsUUID
+from dirty_equals import (
+    FunctionCheck,
+    IsEnum,
+    IsEnumType,
+    IsHash,
+    IsInt,
+    IsIP,
+    IsJson,
+    IsPartialEnumType,
+    IsStr,
+    IsUrl,
+    IsUUID,
+)
 
 
 class ExampleEnum(Enum):
@@ -320,6 +332,7 @@ def test_is_enum_false(other, dirty):
     [
         (ExampleEnum, IsEnumType),
         (ExampleEnum, IsEnumType(a=1, b=2, c='c')),
+        (ExampleEnum, IsEnumType(a=IsInt, b=IsInt, c=IsStr)),
     ],
 )
 def test_is_enum_type_true(other, dirty):
@@ -344,6 +357,7 @@ def test_is_enum_type_false(other, dirty):
         (ExampleEnum, IsPartialEnumType),
         (ExampleEnum, IsPartialEnumType(a=1, b=2, c='c')),
         (ExampleEnum, IsPartialEnumType(a=1, b=2)),
+        (ExampleEnum, IsPartialEnumType(a=IsInt, c=IsStr)),
     ],
 )
 def test_is_partial_enum_type_true(other, dirty):


### PR DESCRIPTION
In a similar fashion to #68, it introduces three types to check enum's:

- `IsEnumType`: checks if a class definition is subclass of `Enum`, and possibly checks exact matching of member values using `IsStrictDict`.
- `IsPartialEnumType`: checks if a class definition is subclass of `Enum`, and possibly checks partial matching of member values using `IsPartialDict`.
- `IsEnum`: checks if an instance is from `Enum` or subclass (arguably this is the most "WIP", since I think it should be possible to check if a value is part of an enum members)

I am tagging this as WIP as we didn't discuss about it.
(Worked on this as it is in the list of #3 )