### PR TITLE
change license to exact

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ path = 'dirty_equals/version.py'
 name = 'dirty-equals'
 description = 'Doing dirty (but extremely useful) things with equals.'
 authors = [{name = 'Samuel Colvin', email = 's@muelcolvin.com'}]
-license = {file = 'LICENSE'}
+license = "MIT"
 readme = 'README.md'
 classifiers = [
     'Development Status :: 4 - Beta',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ path = 'dirty_equals/version.py'
 name = 'dirty-equals'
 description = 'Doing dirty (but extremely useful) things with equals.'
 authors = [{name = 'Samuel Colvin', email = 's@muelcolvin.com'}]
-license = "MIT"
+license = 'MIT'
 readme = 'README.md'
 classifiers = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
Hi! 

Thanks for the great tool.

In our system, we run checks on the licences in the libraries we use and having `file` here adds some complexity in parsing. 
Would it be possible to have a certain license here, as proposed?