### PR TITLE
fix DeprecationWarning with datetime.utcnow()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - run: pip install -r requirements/linting.txt
 

--- a/dirty_equals/_datetime.py
+++ b/dirty_equals/_datetime.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta, timezone, tzinfo, UTC
+from datetime import date, datetime, timedelta, timezone, tzinfo
 from typing import Any, Optional, Union
 
 from ._numeric import IsNumeric
@@ -156,7 +156,7 @@ class IsNow(IsDatetime):
         assert now.isoformat() == IsNow(iso_string=True)
         assert now.isoformat() != IsNow
 
-        utc_now = datetime.now(UTC).replace(tzinfo=timezone.utc)
+        utc_now = datetime.utcnow().replace(tzinfo=timezone.utc)
         assert utc_now == IsNow(tz=timezone.utc)
         ```
         """
@@ -184,7 +184,12 @@ class IsNow(IsDatetime):
         if self.tz is None:
             return datetime.now()
         else:
-            return datetime.now(UTC).replace(tzinfo=timezone.utc).astimezone(self.tz)
+            try:
+                from datetime import UTC
+                utc_now = datetime.now(UTC).replace(tzinfo=timezone.utc)
+            except ImportError:
+                utc_now = datetime.utcnow().replace(tzinfo=timezone.utc)
+            return utc_now.astimezone(self.tz)
 
     def prepare(self, other: Any) -> datetime:
         # update approx for every comparing, to check if other value is dirty equal

--- a/dirty_equals/_datetime.py
+++ b/dirty_equals/_datetime.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta, timezone, tzinfo
+from datetime import date, datetime, timedelta, timezone, tzinfo, UTC
 from typing import Any, Optional, Union
 
 from ._numeric import IsNumeric
@@ -156,7 +156,7 @@ class IsNow(IsDatetime):
         assert now.isoformat() == IsNow(iso_string=True)
         assert now.isoformat() != IsNow
 
-        utc_now = datetime.utcnow().replace(tzinfo=timezone.utc)
+        utc_now = datetime.now(UTC).replace(tzinfo=timezone.utc)
         assert utc_now == IsNow(tz=timezone.utc)
         ```
         """
@@ -184,7 +184,7 @@ class IsNow(IsDatetime):
         if self.tz is None:
             return datetime.now()
         else:
-            return datetime.utcnow().replace(tzinfo=timezone.utc).astimezone(self.tz)
+            return datetime.now(UTC).replace(tzinfo=timezone.utc).astimezone(self.tz)
 
     def prepare(self, other: Any) -> datetime:
         # update approx for every comparing, to check if other value is dirty equal

--- a/dirty_equals/_datetime.py
+++ b/dirty_equals/_datetime.py
@@ -186,6 +186,7 @@ class IsNow(IsDatetime):
         else:
             try:
                 from datetime import UTC
+
                 utc_now = datetime.now(UTC).replace(tzinfo=timezone.utc)
             except ImportError:
                 utc_now = datetime.utcnow().replace(tzinfo=timezone.utc)

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone, UTC
 from unittest.mock import Mock
 
 import pytest
@@ -99,7 +99,7 @@ def test_repr():
 
 
 def test_is_now_tz():
-    now_ny = datetime.utcnow().replace(tzinfo=timezone.utc).astimezone(pytz.timezone('America/New_York'))
+    now_ny = datetime.now(UTC).replace(tzinfo=timezone.utc).astimezone(pytz.timezone('America/New_York'))
     assert now_ny == IsNow(tz='America/New_York')
     # depends on the time of year and DST
     assert now_ny == IsNow(tz=timezone(timedelta(hours=-5))) | IsNow(tz=timezone(timedelta(hours=-4)))
@@ -111,7 +111,7 @@ def test_is_now_tz():
     assert now.isoformat() == IsNow(iso_string=True)
     assert now.isoformat() != IsNow
 
-    utc_now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    utc_now = datetime.now(UTC).replace(tzinfo=timezone.utc)
     assert utc_now == IsNow(tz=timezone.utc)
 
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -101,6 +101,7 @@ def test_repr():
 def test_is_now_tz():
     try:
         from datetime import UTC
+
         utc_now = datetime.now(UTC).replace(tzinfo=timezone.utc)
     except ImportError:
         utc_now = datetime.utcnow().replace(tzinfo=timezone.utc)

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta, timezone, UTC
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import Mock
 
 import pytest
@@ -99,7 +99,12 @@ def test_repr():
 
 
 def test_is_now_tz():
-    now_ny = datetime.now(UTC).replace(tzinfo=timezone.utc).astimezone(pytz.timezone('America/New_York'))
+    try:
+        from datetime import UTC
+        utc_now = datetime.now(UTC).replace(tzinfo=timezone.utc)
+    except ImportError:
+        utc_now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    now_ny = utc_now.astimezone(pytz.timezone('America/New_York'))
     assert now_ny == IsNow(tz='America/New_York')
     # depends on the time of year and DST
     assert now_ny == IsNow(tz=timezone(timedelta(hours=-5))) | IsNow(tz=timezone(timedelta(hours=-4)))
@@ -111,7 +116,6 @@ def test_is_now_tz():
     assert now.isoformat() == IsNow(iso_string=True)
     assert now.isoformat() != IsNow
 
-    utc_now = datetime.now(UTC).replace(tzinfo=timezone.utc)
     assert utc_now == IsNow(tz=timezone.utc)
 
 


### PR DESCRIPTION
This is not the same as https://github.com/samuelcolvin/dirty-equals/issues/71, but it originates at the same point. When I updated pytz to 2023.3.post1, I started getting:
```
E       DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```
This fixes it.