### PR TITLE
chore: use `zoneinfo` instead of `pytz`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
         allow-prereleases: true
 
     - run: pip install -r requirements/tests.txt -r requirements/pyproject.txt
+
     - run: make test
+
     - run: coverage xml
 
     - uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,7 @@ jobs:
         allow-prereleases: true
 
     - run: pip install -r requirements/tests.txt -r requirements/pyproject.txt
-
     - run: make test
-
     - run: coverage xml
 
     - uses: codecov/codecov-action@v3

--- a/dirty_equals/_datetime.py
+++ b/dirty_equals/_datetime.py
@@ -130,12 +130,7 @@ def _zoneinfo(tz: str) -> ZoneInfo:
     try:
         from zoneinfo import ZoneInfo
     except ImportError:
-        try:
-            import pytz
-        except ImportError as e:
-            raise ImportError('`pytz` or `zoneinfo` required for tz handling') from e
-        else:
-            return pytz.timezone(tz)  # type: ignore[return-value]
+        from backports.zoneinfo import ZoneInfo
     else:
         return ZoneInfo(tz)
 

--- a/dirty_equals/_datetime.py
+++ b/dirty_equals/_datetime.py
@@ -127,14 +127,6 @@ class IsDatetime(IsNumeric[datetime]):
             return True
 
 
-def _zoneinfo(tz: str) -> ZoneInfo:
-    """
-    Instantiate a `ZoneInfo` object from a string, falling back to `pytz.timezone` when `ZoneInfo` is not available
-    (most likely on Python 3.8 and webassembly).
-    """
-    return ZoneInfo(tz)
-
-
 class IsNow(IsDatetime):
     """
     Check if a datetime is close to now, this is similar to `IsDatetime(approx=datetime.now())`,
@@ -180,7 +172,7 @@ class IsNow(IsDatetime):
         ```
         """
         if isinstance(tz, str):
-            tz = _zoneinfo(tz)
+            tz = ZoneInfo(tz)
 
         self.tz = tz
 

--- a/dirty_equals/_datetime.py
+++ b/dirty_equals/_datetime.py
@@ -1,13 +1,18 @@
 from __future__ import annotations as _annotations
 
+import sys
 from datetime import date, datetime, timedelta, timezone, tzinfo
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from ._numeric import IsNumeric
 from ._utils import Omit
 
-if TYPE_CHECKING:
+if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
+else:
+    # This code block is due to a typing issue with backports.zoneinfo package:
+    # https://github.com/pganssle/zoneinfo/issues/125
+    from backports.zoneinfo._zoneinfo import ZoneInfo
 
 
 class IsDatetime(IsNumeric[datetime]):
@@ -127,12 +132,7 @@ def _zoneinfo(tz: str) -> ZoneInfo:
     Instantiate a `ZoneInfo` object from a string, falling back to `pytz.timezone` when `ZoneInfo` is not available
     (most likely on Python 3.8 and webassembly).
     """
-    try:
-        from zoneinfo import ZoneInfo
-    except ImportError:
-        from backports.zoneinfo import ZoneInfo
-    finally:
-        return ZoneInfo(tz)
+    return ZoneInfo(tz)
 
 
 class IsNow(IsDatetime):

--- a/dirty_equals/_datetime.py
+++ b/dirty_equals/_datetime.py
@@ -131,7 +131,7 @@ def _zoneinfo(tz: str) -> ZoneInfo:
         from zoneinfo import ZoneInfo
     except ImportError:
         from backports.zoneinfo import ZoneInfo
-    else:
+    finally:
         return ZoneInfo(tz)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 requires-python = '>=3.8'
 dependencies = [
-    'pytz>=2021.3;python_version<"3.9"',
+    'backports.zoneinfo;python_version<"3.9"',
 ]
 optional-dependencies = {pydantic = ['pydantic>=2.4.2'] }
 dynamic = ['version']

--- a/requirements/linting.txt
+++ b/requirements/linting.txt
@@ -16,8 +16,6 @@ pydantic-core==2.20.1
     # via pydantic
 ruff==0.5.7
     # via -r requirements/linting.in
-types-pytz==2024.1.0.20240417
-    # via -r requirements/linting.in
 typing-extensions==4.12.2
     # via
     #   mypy

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -4,4 +4,4 @@ pytest
 pytest-mock
 pytest-pretty
 pytest-examples
-pytz
+backports.zoneinfo;python_version<"3.9"

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -45,7 +45,7 @@ pytest-mock==3.14.0
     # via -r requirements/tests.in
 pytest-pretty==1.2.0
     # via -r requirements/tests.in
-pytz==2024.1
+backports.zoneinfo;python_version<"3.9"
     # via -r requirements/tests.in
 rich==13.7.1
     # via pytest-pretty

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -61,9 +61,7 @@ except ImportError:
         ),
         pytest.param(
             datetime(2022, 2, 15, 15, 15, tzinfo=ZoneInfo('Europe/London')),
-            IsDatetime(
-                approx=datetime(2022, 2, 15, 10, 15, tzinfo=ZoneInfo('America/New_York')), enforce_tz=False
-            ),
+            IsDatetime(approx=datetime(2022, 2, 15, 10, 15, tzinfo=ZoneInfo('America/New_York')), enforce_tz=False),
             True,
             id='tz-both-tz',
         ),

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -2,14 +2,13 @@ from datetime import date, datetime, timedelta, timezone
 from unittest.mock import Mock
 
 import pytest
-import pytz
 
 from dirty_equals import IsDate, IsDatetime, IsNow, IsToday
 
 try:
     from zoneinfo import ZoneInfo
 except ImportError:
-    ZoneInfo = None
+    from backports.zoneinfo import ZoneInfo
 
 
 @pytest.mark.parametrize(
@@ -61,16 +60,16 @@ except ImportError:
             id='tz-1-hour',
         ),
         pytest.param(
-            pytz.timezone('Europe/London').localize(datetime(2022, 2, 15, 15, 15)),
+            datetime(2022, 2, 15, 15, 15, tzinfo=ZoneInfo('Europe/London')),
             IsDatetime(
-                approx=pytz.timezone('America/New_York').localize(datetime(2022, 2, 15, 10, 15)), enforce_tz=False
+                approx=datetime(2022, 2, 15, 10, 15, tzinfo=ZoneInfo('America/New_York')), enforce_tz=False
             ),
             True,
             id='tz-both-tz',
         ),
         pytest.param(
-            pytz.timezone('Europe/London').localize(datetime(2022, 2, 15, 15, 15)),
-            IsDatetime(approx=pytz.timezone('America/New_York').localize(datetime(2022, 2, 15, 10, 15))),
+            datetime(2022, 2, 15, 15, 15, tzinfo=ZoneInfo('Europe/London')),
+            IsDatetime(approx=datetime(2022, 2, 15, 10, 15, tzinfo=ZoneInfo('America/New_York'))),
             False,
             id='tz-both-tz-different',
         ),

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,3 +1,4 @@
+import sys
 from datetime import date, datetime, timedelta, timezone
 from unittest.mock import Mock
 
@@ -5,10 +6,12 @@ import pytest
 
 from dirty_equals import IsDate, IsDatetime, IsNow, IsToday
 
-try:
+if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
+else:
+    # This code block is due to a typing issue with backports.zoneinfo package:
+    # https://github.com/pganssle/zoneinfo/issues/125
+    from backports.zoneinfo._zoneinfo import ZoneInfo
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Closes #98 by preferring ` backports.zoneinfo` to `pytz` for py3.8
