### PR TITLE
fix: `IsJson` and `IsUUID` repr

### DIFF
--- a/dirty_equals/_other.py
+++ b/dirty_equals/_other.py
@@ -40,7 +40,7 @@ class IsUUID(DirtyEquals[UUID]):
         ```
         """
         self.version = version
-        super().__init__(version or plain_repr('*'))
+        super().__init__(version or plain_repr(''))
 
     def equals(self, other: Any) -> bool:
         if isinstance(other, UUID):
@@ -109,7 +109,7 @@ class IsJson(DirtyEquals[JsonType]):
             self.expected_value: Any = expected_kwargs
         else:
             self.expected_value = expected_value
-        super().__init__(plain_repr('*') if expected_value is AnyJson else expected_value)
+        super().__init__(plain_repr('') if expected_value is AnyJson else expected_value)
 
     def __class_getitem__(cls, expected_type: JsonType) -> IsJson[JsonType]:
         return cls(expected_type)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -79,7 +79,7 @@ def test_is_uuid_false_repr():
     is_uuid = IsUUID()
     with pytest.raises(AssertionError):
         assert '123' == is_uuid
-    assert str(is_uuid) == 'IsUUID(*)'
+    assert str(is_uuid) == 'IsUUID()'
 
 
 def test_is_uuid4_false_repr():
@@ -99,7 +99,7 @@ def test_is_json_any_false():
     is_json = IsJson()
     with pytest.raises(AssertionError):
         assert 'foobar' == is_json
-    assert str(is_json) == 'IsJson(*)'
+    assert str(is_json) == 'IsJson()'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Closes #82 by changing `IsJson` and `IsUUID` repr from `IsJson(*)` and `IsUUID(*)`  to  `IsJson()` and `IsUUID()` respectively.

It does not address the [comment](https://github.com/samuelcolvin/dirty-equals/issues/82#issuecomment-1722455394) regarding `IsApprox`.