### PR TITLE
ci.yml workflow: bump upload-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       run: mkdocs build --strict
 
     - name: store docs site
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: docs
         path: site


### PR DESCRIPTION
v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact) are going away end of Januari: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

I was grepping through my repo's and noticed my local dirty-equals clone was still on v3:
https://github.com/samuelcolvin/dirty-equals/blob/065162ac195964df7f5c47288561809e49deac48/.github/workflows/ci.yml#L94

