### PR TITLE
fix(typing): put `EllipsisType` in `LengthType` union

### DIFF
--- a/dirty_equals/_sequence.py
+++ b/dirty_equals/_sequence.py
@@ -6,9 +6,14 @@ from ._utils import Omit, plain_repr
 if TYPE_CHECKING:
     from typing import TypeAlias
 
+if sys.version_info >= (3, 10):
+    from types import EllipsisType
+else:
+    EllipsisType = Any
+
 __all__ = 'HasLen', 'Contains', 'IsListOrTuple', 'IsList', 'IsTuple'
 T = TypeVar('T', List[Any], Tuple[Any, ...])
-LengthType: 'TypeAlias' = 'Union[None, int, Tuple[int, Union[int, Any]]]'
+LengthType: 'TypeAlias' = 'Union[None, int, Tuple[int, Union[int, Any], EllipsisType]]'
 
 
 class HasLen(DirtyEquals[Sized]):


### PR DESCRIPTION
```
tests/integration_python/test_main_cli.py:1481: error: No overload variant of "IsList" matches argument type "EllipsisType"  [call-overload]
tests/integration_python/test_main_cli.py:1481: note: Possible overload variants:
tests/integration_python/test_main_cli.py:1481: note:     def IsList(self, *items: Any, check_order: bool = ..., length: int | tuple[int, int | Any] | None = ...) -> IsList
tests/integration_python/test_main_cli.py:1481: note:     def IsList(self, positions: dict[int, Any], length: int | tuple[int, int | Any] | None = ...) -> IsList
```

An ellipsis is a valid argument, as shown in the docs: https://dirty-equals.helpmanual.io/latest/types/sequence/?h=isl#dirty_equals.IsList.