### PR TITLE
🐛 Fix nested dataclass comparison

### DIFF
--- a/dirty_equals/_other.py
+++ b/dirty_equals/_other.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import asdict, is_dataclass
+from dataclasses import fields, is_dataclass
 from enum import Enum
 from functools import lru_cache
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network, ip_network
@@ -486,10 +486,11 @@ class IsDataclass(DirtyEquals[Any]):
         """
         Checks exactness of fields using [`IsDict`][dirty_equals.IsDict] with given settings.
 
-        Remark that if this method is called, then `other` is an instance of a dataclass, therefore we can call
-        `dataclasses.asdict` to convert to a dict.
+        Remark that if this method is called, then `other` is an instance of a dataclass, therefore we can use
+        `dataclasses.fields` to get its fields. We use a shallow conversion to preserve nested dataclass instances.
         """
-        return asdict(other) == IsDict(self._repr_kwargs).settings(strict=self.strict, partial=self.partial)
+        other_dict = {field.name: getattr(other, field.name) for field in fields(other)}
+        return other_dict == IsDict(self._repr_kwargs).settings(strict=self.strict, partial=self.partial)
 
 
 class IsPartialDataclass(IsDataclass):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -39,6 +39,21 @@ class Foo:
 foo = Foo(1, 2, 'c')
 
 
+@dataclass
+class Address:
+    street: str
+    zip_code: str
+
+
+@dataclass
+class Person:
+    name: str
+    address: Address
+
+
+person = Person(name='Alice', address=Address(street='123 Main St', zip_code='12345'))
+
+
 @pytest.mark.parametrize(
     'other,dirty',
     [
@@ -371,6 +386,10 @@ def test_is_dataclass_true(other, dirty):
 )
 def test_is_dataclass_false(other, dirty):
     assert other != dirty
+
+
+def test_is_dataclass_nested():
+    assert person == IsDataclass(name='Alice', address=IsDataclass(street='123 Main St', zip_code='12345'))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix how `IsDataclass` handles nested dataclasses so they can be compared successfully. Previously something like the following would not work:
```python
from dataclasses import dataclass
from dirty_equals import IsDataclass

@dataclass
class Address:
    street: str
    zip_code: str

@dataclass
class Person:
    name: str
    address: Address

person = Person(
    name='Alice',
    address=Address(street='123 Main St', zip_code='12345'),
)

assert person == IsDataclass(
    name='Alice',
    address=IsDataclass(street='123 Main St', zip_code='12345')
)
```

This is a result of `IsDataclass` converting dataclasses to a dictionary for comparison using `dataclasses.asdict`, which _recursively_ converts dataclasses to plain dictionaries. Thus the inner `IsDataclass` fails, because the other side of the comparison is now a dictionary, not a dataclass.

These changes fix this by shallowly converting the dataclass to a dictionary using [the approach recommended in the dataclasses documentation](https://docs.python.org/3/library/dataclasses.html#dataclasses.asdict):
```python
{field.name: getattr(obj, field.name) for field in fields(obj)}
```

These changes also include a test for nested dataclass comparisons to ensure this works as expected and continues to work in the future.