### PR TITLE
Add support for uuid v6, v7 and v8 check

### DIFF
--- a/dirty_equals/_other.py
+++ b/dirty_equals/_other.py
@@ -22,7 +22,7 @@ class IsUUID(DirtyEquals[UUID]):
     A class that checks if a value is a valid UUID, optionally checking UUID version.
     """
 
-    def __init__(self, version: Literal[None, 1, 2, 3, 4, 5] = None):
+    def __init__(self, version: Literal[None, 1, 2, 3, 4, 5, 6, 7, 8] = None):
         """
         Args:
             version: The version of the UUID to check, if omitted, all versions are accepted.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -69,6 +69,7 @@ person = Person(name='Alice', address=Address(street='123 Main St', zip_code='12
         (uuid.uuid1(), IsUUID(1)),
         (str(uuid.uuid1()), IsUUID(1)),
         ('ea9e828d-fd18-3898-99f3-5a46dbcee036', IsUUID(3)),
+        ('019a968b-403c-759f-b756-f8b9fd4d2281', IsUUID(7)),
     ],
 )
 def test_is_uuid_true(other, dirty):


### PR DESCRIPTION
UUID v6, v7 and v8 already are part of to standard `uuid` package in `python3.14` and their support can be easily implemented by extending the `IsUUID` version literal