### PR TITLE
Fix IsNow/IsDatetime unix_number comparison with timezone

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,9 @@
+Fix IsNow/IsDatetime unix_number with timezone
+
+When using unix_number=True with a timezone (e.g. IsNow(unix_number=True,
+tz="UTC")), datetime.fromtimestamp() was called without a timezone, producing
+a naive datetime. This caused the comparison to fail because the approx
+datetime had a timezone but the converted timestamp did not.
+
+Pass the approx datetime's timezone to fromtimestamp() so both datetimes
+have matching timezone info.

--- a/dirty_equals/_datetime.py
+++ b/dirty_equals/_datetime.py
@@ -88,7 +88,8 @@ class IsDatetime(IsNumeric[datetime]):
             dt = other
         elif isinstance(other, (float, int)):
             if self.unix_number:
-                dt = datetime.fromtimestamp(other)
+                tz = self.approx.tzinfo if self.approx is not None else None
+                dt = datetime.fromtimestamp(other, tz=tz)
             else:
                 raise TypeError('numbers not allowed')
         elif isinstance(other, str):

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -121,6 +121,10 @@ def test_is_now_tz():
 
     assert utc_now == IsNow(tz=timezone.utc)
 
+    # unix_number with tz should work (#113)
+    assert utc_now.timestamp() == IsNow(unix_number=True, tz='UTC')
+    assert utc_now.timestamp() == IsNow(unix_number=True, tz=timezone.utc)
+
 
 def test_delta():
     assert IsNow(delta=timedelta(hours=2)).delta == timedelta(seconds=7200)


### PR DESCRIPTION
Fixes #113.

`IsNow(unix_number=True, tz="UTC")` was failing because `datetime.fromtimestamp()` was called without a timezone, creating a naive datetime. When the `approx` datetime has timezone info (from the `tz` parameter), `approx_equals()` then sees a timezone mismatch and rejects the comparison.

The fix passes the `approx` datetime's timezone to `fromtimestamp()` so the converted timestamp gets the same timezone, making the comparison work correctly.

Added test assertions for `IsNow(unix_number=True, tz='UTC')` and `IsNow(unix_number=True, tz=timezone.utc)`.
