### PR TITLE
fix: correct enforce_tz repr in IsDatetime

### DIFF
--- a/dirty_equals/_datetime.py
+++ b/dirty_equals/_datetime.py
@@ -80,7 +80,7 @@ class IsDatetime(IsNumeric[datetime]):
             unix_number=Omit if unix_number is False else unix_number,
             iso_string=Omit if iso_string is False else iso_string,
             format_string=Omit if format_string is None else format_string,
-            enforce_tz=Omit if enforce_tz is True else format_string,
+            enforce_tz=Omit if enforce_tz is True else enforce_tz,
         )
 
     def prepare(self, other: Any) -> datetime:

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -104,6 +104,11 @@ def test_repr():
     assert str(v) == 'IsDatetime(approx=datetime.datetime(2032, 1, 2, 3, 4, 5), iso_string=True)'
 
 
+def test_repr_enforce_tz_false():
+    v = IsDatetime(approx=datetime(2032, 1, 2, 3, 4, 5), enforce_tz=False)
+    assert str(v) == 'IsDatetime(approx=datetime.datetime(2032, 1, 2, 3, 4, 5), enforce_tz=False)'
+
+
 @pytest.mark.skipif(ZoneInfo is None, reason='requires zoneinfo')
 def test_is_now_tz():
     utc_now = datetime.now(timezone.utc)


### PR DESCRIPTION

**Repo:** samuelcolvin/dirty-equals (⭐ 900)
**Type:** bugfix
**Files changed:** 2
**Lines:** +6/-1

## What
In `dirty_equals/_datetime.py`, the `IsDatetime.__init__` method sets `_repr_kwargs`
for the `enforce_tz` argument but incorrectly references `format_string` as the
displayed value (`enforce_tz=Omit if enforce_tz is True else format_string`).
This means when `enforce_tz=False` is passed, the repr shows the value of
`format_string` (often `None`) under the `enforce_tz` key instead of `False`.
The fix uses `enforce_tz` as intended. A new test asserts the repr.

## Why
The bug silently produces misleading reprs (e.g., `IsDatetime(..., enforce_tz=None)`
when the user passed `enforce_tz=False`). Accurate reprs matter for debugging
failed assertions, which is the main purpose of `dirty-equals`.

## Testing
- Added `test_repr_enforce_tz_false` in `tests/test_datetime.py`.
- Ran `pytest tests/test_datetime.py::test_repr tests/test_datetime.py::test_repr_enforce_tz_false` — both pass.

## Risk
Low — one-line fix to a repr formatting expression with a targeted new test; no behavior change to equality logic.
