### PR TITLE
feat: add IsBool strict boolean check (closes #115)

### DIFF
--- a/dirty_equals/__init__.py
+++ b/dirty_equals/__init__.py
@@ -1,5 +1,5 @@
 from ._base import AnyThing, DirtyEquals, IsOneOf
-from ._boolean import IsFalseLike, IsTrueLike
+from ._boolean import IsBool, IsFalseLike, IsTrueLike
 from ._datetime import IsDate, IsDatetime, IsNow, IsToday
 from ._dict import IsDict, IsIgnoreDict, IsPartialDict, IsStrictDict
 from ._inspection import HasAttributes, HasName, HasRepr, IsInstance
@@ -47,6 +47,7 @@ __all__ = (
     # boolean
     'IsTrueLike',
     'IsFalseLike',
+    'IsBool',
     # dataclass
     'IsDataclass',
     'IsDataclassType',

--- a/dirty_equals/_boolean.py
+++ b/dirty_equals/_boolean.py
@@ -77,3 +77,30 @@ class IsFalseLike(DirtyEquals[bool]):
             return float(other) == 0
         except ValueError:
             return False
+
+
+class IsBool(DirtyEquals[bool]):
+    """
+    Check if the value is a boolean, that is exactly `True` or `False`.
+
+    Unlike [`IsTrueLike`][dirty_equals.IsTrueLike] and [`IsFalseLike`][dirty_equals.IsFalseLike], this
+    performs a strict check and does not coerce other types: a comparison only succeeds for the actual
+    `bool` values `True` and `False`, and notably **not** for the integers `1` and `0` (even though
+    `True == 1` and `False == 0` in Python).
+
+    Example of basic usage:
+
+    ```py title="IsBool"
+    from dirty_equals import IsBool
+
+    assert True == IsBool
+    assert False == IsBool
+    assert 1 != IsBool
+    assert 0 != IsBool
+    assert None != IsBool
+    assert 'true' != IsBool
+    ```
+    """
+
+    def equals(self, other: Any) -> bool:
+        return other is True or other is False

--- a/docs/types/boolean.md
+++ b/docs/types/boolean.md
@@ -3,3 +3,5 @@
 ::: dirty_equals.IsTrueLike
 
 ::: dirty_equals.IsFalseLike
+
+::: dirty_equals.IsBool

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -2,7 +2,7 @@ import platform
 
 import pytest
 
-from dirty_equals import IsFalseLike, IsTrueLike
+from dirty_equals import IsBool, IsFalseLike, IsTrueLike
 
 
 @pytest.mark.parametrize(
@@ -83,3 +83,42 @@ def test_invalid_initialization():
 )
 def test_is_true_like(other, expected):
     assert other == expected
+
+
+@pytest.mark.parametrize(
+    'other, expected',
+    [
+        (True, IsBool),
+        (False, IsBool),
+        (1, ~IsBool),
+        (0, ~IsBool),
+        (1.0, ~IsBool),
+        (0.0, ~IsBool),
+        (None, ~IsBool),
+        ('True', ~IsBool),
+        ('', ~IsBool),
+        ([], ~IsBool),
+        ([True], ~IsBool),
+        ({}, ~IsBool),
+    ],
+)
+def test_is_bool(other, expected):
+    assert other == expected
+
+
+def test_is_bool_repr():
+    assert repr(IsBool) == 'IsBool'
+    assert repr(IsBool()) == 'IsBool()'
+
+
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='PyPy does not metaclass dunder methods')
+def test_is_bool_dirty_not_equals():
+    value = True
+    with pytest.raises(AssertionError):
+        assert value != IsBool
+
+
+def test_is_bool_dirty_not_equals_instance():
+    value = True
+    with pytest.raises(AssertionError):
+        assert value != IsBool()


### PR DESCRIPTION
Closes #115.

## Summary
Adds a new `IsBool` type that strictly checks a value is a boolean — exactly `True` or `False`.

Unlike `IsTrueLike` / `IsFalseLike`, `IsBool` performs **no type coercion**: `1`/`0`, `None`, empty/non-empty containers and strings do **not** match. This makes it possible to assert that a value is an actual `bool`, e.g.:

```py
from dirty_equals import IsBool, IsDict

assert response.json() == IsDict(active=IsBool)  # active must be a real bool, not 0/1
```

This was explicitly requested and approved by the maintainer in #115 ("Happy to accept a PR to add `IsBool`.").

## Changes
- `dirty_equals/_boolean.py`: new `IsBool(DirtyEquals[bool])` with a documented example.
- `dirty_equals/__init__.py`: export `IsBool` (import + `__all__`).
- `docs/types/boolean.md`: add `IsBool` to the rendered API docs.
- `tests/test_boolean.py`: parametrized matches/non-matches, repr, and `!=` behaviour.

## Validation
- `ruff format --check` and `ruff check dirty_equals tests` — clean.
- `pytest tests/test_boolean.py` — 59 passed.
- `mypy dirty_equals` — no new errors introduced by `IsBool` (pre-existing `_numeric.py` warnings only, present on `main`).
- Behaviour: `True == IsBool`, `False == IsBool`, `1 != IsBool`, `0 != IsBool`, `None != IsBool`, `'true' != IsBool`.
