### PR TITLE
Fix IsDatetime repr showing format_string in place of enforce_tz

### DIFF
--- a/dirty_equals/_datetime.py
+++ b/dirty_equals/_datetime.py
@@ -80,7 +80,7 @@ class IsDatetime(IsNumeric[datetime]):
             unix_number=Omit if unix_number is False else unix_number,
             iso_string=Omit if iso_string is False else iso_string,
             format_string=Omit if format_string is None else format_string,
-            enforce_tz=Omit if enforce_tz is True else format_string,
+            enforce_tz=Omit if enforce_tz is True else enforce_tz,
         )
 
     def prepare(self, other: Any) -> datetime:

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -104,6 +104,11 @@ def test_repr():
     assert str(v) == 'IsDatetime(approx=datetime.datetime(2032, 1, 2, 3, 4, 5), iso_string=True)'
 
 
+def test_repr_enforce_tz():
+    v = IsDatetime(approx=datetime(2032, 1, 2, 3, 4, 5), enforce_tz=False)
+    assert str(v) == 'IsDatetime(approx=datetime.datetime(2032, 1, 2, 3, 4, 5), enforce_tz=False)'
+
+
 @pytest.mark.skipif(ZoneInfo is None, reason='requires zoneinfo')
 def test_is_now_tz():
     utc_now = datetime.now(timezone.utc)


### PR DESCRIPTION
### Summary

`IsDatetime.__init__` builds its repr kwargs with a copy-paste slip: the `enforce_tz` entry uses `format_string` as its value instead of `enforce_tz`.

```python
self._repr_kwargs.update(
    unix_number=Omit if unix_number is False else unix_number,
    iso_string=Omit if iso_string is False else iso_string,
    format_string=Omit if format_string is None else format_string,
    enforce_tz=Omit if enforce_tz is True else format_string,  # <-- should be enforce_tz
)
```

The three sibling lines all follow `Omit if <default> else <that same variable>`, so `enforce_tz` should reference `enforce_tz`.

Observable effect (the repr is what pytest prints on a failed assertion, so it's user-facing):

```python
>>> repr(IsDatetime(approx=dt, enforce_tz=False))
'IsDatetime(approx=..., enforce_tz=None)'                       # wrong
>>> repr(IsDatetime(approx=dt, enforce_tz=False, format_string='%Y'))
"IsDatetime(approx=..., format_string='%Y', enforce_tz='%Y')"   # echoes the format string
```

### Fix

`else format_string` → `else enforce_tz`. After the fix, `enforce_tz=False` reprs as `enforce_tz=False`, and the default `enforce_tz=True` is still correctly omitted.

### Tests

Added `test_repr_enforce_tz`. `ruff format --check` / `ruff check` clean; `tests/test_datetime.py` passes locally (aside from two pre-existing `test_is_datetime[unix-*]` cases that fail on `main` in my local timezone, unrelated to this change).
