### PR TITLE
Fix IsIP comparison when an ipaddress network is on the left-hand side

### DIFF
--- a/dirty_equals/_other.py
+++ b/dirty_equals/_other.py
@@ -358,10 +358,13 @@ class IsIP(DirtyEquals[IP]):
         assert 3232235521 == IsIP
         ```
         """
-        self.version = version
-        if netmask and not self.version:
+        # NOTE: these are deliberately private. `ipaddress._BaseNetwork.__eq__` is duck-typed on
+        # `other.version`/`other.netmask`, so public attributes of those names make it return
+        # `False` instead of `NotImplemented`, and our reflected `__eq__` is never called.
+        self._version = version
+        if netmask and not self._version:
             raise TypeError('To check the netmask you must specify the IP version')
-        self.netmask = netmask
+        self._netmask = netmask
         super().__init__(version=version or Omit, netmask=netmask or Omit)
 
     def equals(self, other: Any) -> bool:
@@ -372,13 +375,13 @@ class IsIP(DirtyEquals[IP]):
         else:
             return False
 
-        if self.version:
-            if self.netmask:
-                version_check = self.version == ip.version
-                address_format = {4: IPv4Address, 6: IPv6Address}[self.version]
-                netmask_check = int(address_format(self.netmask)) == int(ip.netmask)
+        if self._version:
+            if self._netmask:
+                version_check = self._version == ip.version
+                address_format = {4: IPv4Address, 6: IPv6Address}[self._version]
+                netmask_check = int(address_format(self._netmask)) == int(ip.netmask)
                 return version_check and netmask_check
-            elif self.version != ip.version:
+            elif self._version != ip.version:
                 return False
 
         return True

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -248,6 +248,20 @@ def test_ip_bad_netmask():
 
 
 @pytest.mark.parametrize(
+    'network',
+    [
+        IPv4Network('43.48.0.0/12'),
+        IPv6Network('::eeff:ae3f:d473/128'),
+    ],
+)
+def test_is_ip_network_left_hand_side(network):
+    # `_BaseNetwork.__eq__` is duck-typed on `other.version`/`other.netmask`, so `IsIP` must not
+    # expose attributes with those names or it never gets a chance to compare (see #112).
+    assert network == IsIP()
+    assert network != IsIP(version=6 if network.version == 4 else 4)
+
+
+@pytest.mark.parametrize(
     'other,dirty',
     [
         ('f1e069787ECE74531d112559945c6871', IsHash('md5')),


### PR DESCRIPTION
Closes #112

`ipaddress._BaseNetwork.__eq__` is duck-typed on `other.version` and `other.netmask`, so `IsIP`'s public attributes of those names made it return `False` rather than `NotImplemented` — meaning Python never fell back to `IsIP.__eq__` and `IPv4Network('43.48.0.0/12') == IsIP()` was False whenever the network was on the left-hand side. Renaming them to `_version`/`_netmask` restores the reflected comparison.

The two `test_is_ip_true` cases the issue reports now pass on 3.14 (they were `xfail`ed); the new `test_is_ip_network_left_hand_side` fails without the source change and passes with it.
