### PR TITLE
Fix: IsDatetime.prepare() (dirty_equals/_datetime.py) only reconciled tzinfo...

### DIFF
--- a/dirty_equals/_datetime.py
+++ b/dirty_equals/_datetime.py
@@ -101,8 +101,19 @@ class IsDatetime(IsNumeric[datetime]):
         else:
             raise ValueError(f'{type(other)} not valid as datetime')
 
-        if self.approx is not None and not self.enforce_tz and self.approx.tzinfo is None and dt.tzinfo is not None:
-            dt = dt.replace(tzinfo=None)
+        if self.approx is not None and not self.enforce_tz:
+            if self.approx.tzinfo is None and dt.tzinfo is not None:
+                dt = dt.replace(tzinfo=None)
+            elif self.approx.tzinfo is not None and dt.tzinfo is None and isinstance(other, str):
+                # `other` was a string parsed via `iso_string`/`format_string` with no timezone offset in it
+                # (e.g. a literal 'Z' consumed by `format_string` instead of being parsed as an offset), so
+                # there was never any way for it to carry timezone info of its own. Since `approx` is
+                # timezone-aware and enforce_tz is False, assume the parsed value was meant to represent a
+                # point in time in approx's timezone, so the delta comparison below is meaningful instead of
+                # raising a TypeError (naive minus aware) that would otherwise be silently swallowed as a
+                # non-match. This does not apply to a real `datetime` object passed in naive, since there's
+                # no evidence at all of what timezone (if any) it was meant to represent.
+                dt = dt.replace(tzinfo=self.approx.tzinfo)
         return dt
 
     def approx_equals(self, other: datetime, delta: timedelta) -> bool:

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -134,6 +134,23 @@ def test_is_now_relative(monkeypatch):
     assert IsNow() == datetime(2020, 1, 1, 12, 13, 14)
 
 
+def test_is_now_tz_format_string_enforce_tz_false(monkeypatch):
+    # https://github.com/samuelcolvin/dirty-equals/issues/48
+    # `format_string` with a literal 'Z' (rather than `%z`) parses to a naive datetime, since strptime
+    # consumes the 'Z' as a plain character rather than a UTC offset. With `enforce_tz=False` and `tz='utc'`,
+    # the naive parsed value should still be compared against `approx` on delta alone, instead of silently
+    # failing to match because of a `TypeError` from mixing naive and aware datetimes.
+    mock = Mock(return_value=datetime(2022, 7, 15, 10, 56, 30, tzinfo=timezone.utc))
+    monkeypatch.setattr(IsNow, '_get_now', mock)
+
+    assert '2022-07-15T10:56:38.311Z' == IsNow(
+        delta=10, tz='utc', format_string='%Y-%m-%dT%H:%M:%S.%fZ', enforce_tz=False
+    )
+    assert '2022-07-15T10:00:00.000Z' != IsNow(
+        delta=10, tz='utc', format_string='%Y-%m-%dT%H:%M:%S.%fZ', enforce_tz=False
+    )
+
+
 @pytest.mark.skipif(ZoneInfo is None, reason='requires zoneinfo')
 def test_tz():
     new_year_london = datetime(2000, 1, 1, tzinfo=ZoneInfo('Europe/London'))


### PR DESCRIPTION
## Summary
In IsDatetime.prepare(), added the missing direction: when approx is timezone-aware, dt is naive, enforce_tz is False, AND the original `other` value was a string (parsed via iso_string/format_string) rather than a raw datetime object, attach approx's tzinfo to dt before returning it, so the delta comparison downstream is meaningful instead of raising. The check is deliberately scoped to string-parsed inputs: a raw naive `datetime` object carries no evidence at all of what timezone (if any) it represents, and the existing test suite (test_tz, tz-approx-tz in tests/test_datetime.py, matching docs/types/datetime.md) explicitly asserts that a naive datetime object should NOT match an aware approx even under enforce_tz=False. A string parsed from format_string/iso_string with no offset in it (e.g. a literal 'Z') has no other way to carry timezone info, so assuming it represents a point in time in approx's timezone is the only way to give meaning to enforce_tz=False + tz=... for that case, and does not disturb the datetime-object semantics documented and tested elsewhere.

## Problem
samuelcolvin/dirty-equals issue reference: samuelcolvin/dirty-equals#48

## Root Cause
IsDatetime.prepare() (dirty_equals/_datetime.py) only reconciled tzinfo in one direction: when approx is naive and dt (the parsed/compared value) is aware, it stripped dt's tzinfo. It never handled the opposite case: approx aware (tz='utc' set) and dt naive (because format_string's literal 'Z' is consumed by strptime as a plain character, not parsed as a UTC offset, so the resulting datetime has tzinfo=None). This left one aware and one naive datetime; the delta subtraction in IsNumeric's comparison then raised TypeError, which DirtyEquals.__eq__ catches and silently converts to a non-match (False) - invisible to the caller.

## Testing
PASS - new regression test passes; full suite (excluding test_docs.py, which needs extra deps) shows only the 5 known pre-existing failures listed in the task feedback (test_is_datetime[unix-float], test_is_datetime[unix-int], test_has_repr, test_anything_diff, test_islist_diff), none of which are related to this change or newly introduced.

## Related Issue
samuelcolvin/dirty-equals#48
