### PR TITLE
Fix: Make DirtyEquals objects hashable

### DIFF
--- a/dirty_equals/_base.py
+++ b/dirty_equals/_base.py
@@ -61,6 +61,8 @@ class DirtyEquals(Generic[T], metaclass=DirtyEqualsMeta):
 
     __slots__ = '_other', '_was_equal', '_repr_args', '_repr_kwargs'
 
+    __hash__ = object.__hash__
+
     def __init__(self, *repr_args: Any, **repr_kwargs: Any):
         """
         Args:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -106,6 +106,13 @@ def test_is_uuid4_false_repr():
     assert str(is_uuid) == 'IsUUID(4)'
 
 
+def test_is_uuid_hashable():
+    # see https://github.com/samuelcolvin/dirty-equals/issues/138
+    is_uuid = IsUUID()
+    assert isinstance(hash(is_uuid), int)
+    assert is_uuid in {is_uuid: 'bla'}
+
+
 @pytest.mark.parametrize('json_value', ['null', '"xyz"', '[1, 2, 3]', '{"a": 1}'])
 def test_is_json_any_true(json_value):
     assert json_value == IsJson()


### PR DESCRIPTION
Fixes #138

This change restores `__hash__ = object.__hash__` for `DirtyEquals` instances to make them hashable (which they implicitly lose by defining `__eq__`). This allows using them in sets and dictionary keys without raising `TypeError: unhashable type`. Added a test for `IsUUID`.